### PR TITLE
Fix for sparse matrix error for scipy 1.11

### DIFF
--- a/hidef/utils.py
+++ b/hidef/utils.py
@@ -54,6 +54,8 @@ def jaccard_matrix(matA, matB, threshold=0.75, return_mat=False):  # assume matA
 
     either = (np.tile(matA.getnnz(axis=1), (matB.shape[0], 1)) + matB.getnnz(axis=1)[:, np.newaxis]).T - both
     jac = 1.0 * both / either
+    if isinstance(jac, (csr_matrix, coo_matrix)):
+        jac = jac.toarray()
     index = np.where(jac > threshold)
     if not return_mat:
         return index


### PR DESCRIPTION
Hi Fan,
 I am a software developer in the Ideker lab and I ran into an issue where HiDeF fails to run on versions of Python above 3.8. More specifically I found out that scipy 1.11.x has a breaking change. 

The error I ran into:

```bash
clusters\n@> Resolution: 11.7470; find 18 clusters\n@> Resolution: 18.2582; find 20 clusters\n@> Resolution: 41.2850;
 find 20 clusters\n@> Resolution: 29.0112; find 20 clusters\n@> Resolution: 0.0736; find 4 clusters\n@> Resolution: 
34.6082; find 20 clusters\n@> Resolution: 44.1085; find 20 clusters\n@> Resolution: 0.0918; find 4 clusters\n@> 
Resolution: 24.3194; find 20 clusters\nTraceback (most recent call last):\n  File 
"/cellar/users/jlenkiewicz/miniconda3/envs/test_39/bin/hidef_finder.py", line 742, in <module>\n    cluG = run(Gs,\n  File 
"/cellar/users/jlenkiewicz/miniconda3/envs/test_39/bin/hidef_finder.py", line 417, in run\n    
cluG.add_clusters(resolution_graph, all_resolutions[i])\n  File 
"/cellar/users/jlenkiewicz/miniconda3/envs/test_39/bin/hidef_finder.py", line 112, in add_clusters\n    id_new, id_r = 
jaccard_matrix(new_mat, rmat, self.graph[\'sim_threshold\'])\n  File 
"/cellar/users/jlenkiewicz/miniconda3/envs/test_39/lib/python3.9/site-packages/hidef/utils.py", line 57, in jaccard_matrix\n 
   index = np.where(jac > threshold)\n  File "/cellar/users/jlenkiewicz/miniconda3/envs/test_39/lib/python3.9/site-
packages/scipy/sparse/_base.py", line 332, in __bool__\n    raise ValueError("The truth value of an array with more than 
one "\nValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all().\n'

```

This pull request is a fix we think corrects the issue. Please double check this does not break things or perform an incorrect operation.

thanks,

Joanna